### PR TITLE
Add Anonymize IP Property

### DIFF
--- a/components/SimpleGoogleAnalytics.php
+++ b/components/SimpleGoogleAnalytics.php
@@ -5,14 +5,22 @@
     use Cms\Classes\ComponentBase;
     use Cms\Classes\Page;
     use Lang;
+    use Event;
 
     class SimpleGoogleAnalytics extends ComponentBase {
+
+        public $extendedTrackingCode;
 
         public function componentDetails() {
             return [
                 'name'        => 'martin.simplegoogleanalytics::lang.components.simplegoogleanalytics.name',
                 'description' => 'martin.simplegoogleanalytics::lang.components.simplegoogleanalytics.description'
             ];
+        }
+
+        public function onRender() {
+            $trackingCodeExtensions = Event::fire('googleanalytics.extend_tracking_code');
+            $this->extendedTrackingCode = implode($trackingCodeExtensions, "\n");
         }
 
         public function defineProperties() {

--- a/components/SimpleGoogleAnalytics.php
+++ b/components/SimpleGoogleAnalytics.php
@@ -33,6 +33,14 @@
                     'type'              => 'string',
                     'required'          => true,
                     'showExternalParam' => false
+                ],
+                'anonymize_ip' => [
+                    'title'             => Lang::get('martin.simplegoogleanalytics::lang.components.simplegoogleanalytics.anonymize_ip_title'),
+                    'description'       => Lang::get('martin.simplegoogleanalytics::lang.components.simplegoogleanalytics.anonymize_ip_desc'),
+                    'default'           => false,
+                    'type'              => 'checkbox',
+                    'required'          => false,
+                    'showExternalParam' => false
                 ]
             ];
             return $properties;

--- a/components/simplegoogleanalytics/default.htm
+++ b/components/simplegoogleanalytics/default.htm
@@ -7,6 +7,6 @@
 	{% if __SELF__.property('anonymize_ip') %}
 	ga('set', 'anonymizeIp', true);
 	{% endif %}
-	{{ __SELF__.extendedTrackingCode }}
+	{{ __SELF__.extendedTrackingCode|raw }}
     ga('send', 'pageview');
 </script>

--- a/components/simplegoogleanalytics/default.htm
+++ b/components/simplegoogleanalytics/default.htm
@@ -7,5 +7,6 @@
 	{% if __SELF__.property('anonymize_ip') %}
 	ga('set', 'anonymizeIp', true);
 	{% endif %}
+	{{ __SELF__.extendedTrackingCode }}
     ga('send', 'pageview');
 </script>

--- a/components/simplegoogleanalytics/default.htm
+++ b/components/simplegoogleanalytics/default.htm
@@ -4,5 +4,8 @@
         m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
     })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
     ga('create', '{{ __SELF__.property('tracking_id') }}', '{{ __SELF__.property('domain') }}');
+	{% if __SELF__.property('anonymize_ip') %}
+	ga('set', 'anonymizeIp', true);
+	{% endif %}
     ga('send', 'pageview');
 </script>

--- a/lang/en/lang.php
+++ b/lang/en/lang.php
@@ -9,12 +9,14 @@
 
         'components' => [
             'simplegoogleanalytics' => [
-                'name'          => 'Google Analytics tracking code',
-                'description'   => 'Add Google Analytics tracking code to your page',
-                'track_id'      => 'Tracking ID',
-                'track_id_desc' => 'Google Analytics Tracking ID',
-                'domain'        => 'Set custom domain',
-                'domain_desc'   => 'Set domain to track'
+                'name'               => 'Google Analytics tracking code',
+                'description'        => 'Add Google Analytics tracking code to your page',
+                'track_id'           => 'Tracking ID',
+                'track_id_desc'      => 'Google Analytics Tracking ID',
+                'domain'             => 'Set custom domain',
+                'domain_desc'        => 'Set domain to track',
+                'anonymize_ip_title' => 'Anonymize IP',
+                'anonymize_ip_desc'  => 'Hide special parts of the visitors IP-Address'
             ]
         ]
 

--- a/updates/version.yaml
+++ b/updates/version.yaml
@@ -1,2 +1,4 @@
 1.0.1:
     - Simple Google Analytics initial release
+1.0.2:
+    - Add Anonymize IP Property


### PR DESCRIPTION
In many Countries - especially in Europe, it's neccessary to anonymize the users IP when the site is traccked by Google Analytics. So, I added this as another property.